### PR TITLE
Uneven number of sponsors

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -883,6 +883,14 @@ iframe#speakers {
   .sponsors__sponsor.cisco img {
     max-height: 10rem;
   }
+
+  .sponsors__sponsor.crowdstrike {
+    grid-column: span 2;
+  }
+
+  .sponsors__sponsor.crowdstrike img {
+    max-width: 35rem;
+  }
 }
 
 .sponsorships {


### PR DESCRIPTION
- Makes crowdstrike center in the grid when sponsors shown in 2 columns (but not too wide)